### PR TITLE
feat: add mod-auth-oauth2 to keystone

### DIFF
--- a/kolla-build.conf
+++ b/kolla-build.conf
@@ -19,4 +19,4 @@ type = local
 location = patches/neutron-bgp-dragent/
 
 [profiles]
-custom = fluentd,neutron-l3-agent,neutron-bgp-dragent
+custom = fluentd,^keystone$,neutron-l3-agent,neutron-bgp-dragent

--- a/template_overrides.j2
+++ b/template_overrides.j2
@@ -3,6 +3,15 @@
 # fluentd
 {% set fluentd_plugins_append = ['fluent-plugin-grafana-loki'] %}
 
+# keystone
+{% block keystone_footer %}
+RUN dnf install -y --enablerepo epel \
+    https://github.com/OpenIDC/liboauth2/releases/download/v2.0.0/liboauth2-2.0.0-1.el9.x86_64.rpm \
+    https://github.com/OpenIDC/liboauth2/releases/download/v2.0.0/liboauth2-apache-2.0.0-1.el9.x86_64.rpm \
+    https://github.com/OpenIDC/mod_oauth2/releases/download/v4.0.0/mod_oauth2-4.0.0-1.el9.x86_64.rpm \
+    && dnf clean all
+{% endblock %}
+
 # neutron
 {% set neutron_base_packages_append = ['patch'] %}
 {% block neutron_l3_agent_footer %}


### PR DESCRIPTION
Adds mod_oauth2 to httpd in keystone image for JWT-based authentication with multiple identity providers.